### PR TITLE
fix(gateway): fix withdrawal edge-case

### DIFF
--- a/contracts/gateway.fc
+++ b/contracts/gateway.fc
@@ -32,7 +32,7 @@ const op::authority::update_authority = 204;
 const gas::deposit = 10000;
 const gas::deposit_and_call = 13000;
 const gas::authority = 20000;
-const gas::withdraw = 17000;
+const gas::withdraw = 17500;
 
 ;; PARSING =========================================
 
@@ -302,17 +302,20 @@ cell auth::ecdsa::external(slice message, slice expected_evm_address) inline {
 
     int tx_fee = get_gas_fee_workchain(gas::withdraw);
 
+    throw_if(error::insufficient_value, state::total_locked < (amount + tx_fee));
+
     ;; Accept the message, the contract agrees to pay gas fees
     accept_message();
 
     state::total_locked -= (amount + tx_fee);
     state::seqno += 1;
 
+    mutate_state();
+    commit();
+
     ;; Sent TON and mutate the state
     int send_mode = message::flag::pay_fees_separately;
     send_simple_message_non_bounceable(recipient_addr, amount, send_mode);
-
-    mutate_state();
 }
 
 ;; Entry point for all external messages

--- a/contracts/gateway.fc
+++ b/contracts/gateway.fc
@@ -302,6 +302,7 @@ cell auth::ecdsa::external(slice message, slice expected_evm_address) inline {
 
     int tx_fee = get_gas_fee_workchain(gas::withdraw);
 
+    ;; edge-case: make sure gw has enough coins when having low funds
     throw_if(error::insufficient_value, state::total_locked < (amount + tx_fee));
 
     ;; Accept the message, the contract agrees to pay gas fees

--- a/scripts/transaction.ts
+++ b/scripts/transaction.ts
@@ -24,7 +24,16 @@ export async function run(p: NetworkProvider) {
     const gw = await open(p);
 
     // can be extended in the future
-    const commands = ['deposit', 'depositAndCall', 'donate', 'send', 'withdraw', 'getState'];
+    const commands = [
+        'deposit',
+        'depositAndCall',
+        'donate',
+        'send',
+        'withdraw',
+        'getState',
+        'getSeqno',
+    ];
+
     const cmd = await p.ui().choose('Select command', commands, (cmd) => cmd);
 
     switch (cmd) {
@@ -47,7 +56,9 @@ export async function run(p: NetworkProvider) {
                 authority: state.authority.toRawString(),
             });
             return;
-
+        case 'getSeqno':
+            console.log('Gateway seqno:', await gw.getSeqno());
+            return;
         default:
             console.log(`Unknown command ${cmd}`);
             return;


### PR DESCRIPTION
This should not happen, but if so - the gateway could have been drained by gas fees and infinite retry when the signed withdrawal amount is larger than `total_locked` funds