### PR TITLE
fix(gateway)!: seqno offset

### DIFF
--- a/contracts/gateway.fc
+++ b/contracts/gateway.fc
@@ -298,7 +298,7 @@ cell auth::ecdsa::external(slice message, slice expected_evm_address) inline {
     throw_if(error::invalid_tvm_recipient, equal_slices(recipient, my_address()));
 
     throw_if(error::insufficient_value, amount == 0);
-    throw_if(error::invalid_seqno, seqno != (state::seqno + 1));
+    throw_if(error::invalid_seqno, seqno != state::seqno);
 
     int tx_fee = get_gas_fee_workchain(gas::withdraw);
 

--- a/wrappers/Gateway.ts
+++ b/wrappers/Gateway.ts
@@ -183,7 +183,7 @@ export class Gateway implements Contract {
         recipient: Address,
         amount: bigint,
     ) {
-        const seqno = await this.getNextSeqno(provider);
+        const seqno = await this.getSeqno(provider);
         const payload = beginCell()
             .storeUint(GatewayOp.Withdraw, 32)
             .storeAddress(recipient)
@@ -255,10 +255,6 @@ export class Gateway implements Contract {
         const response = await provider.get('calculate_gas_fee', [bigOp]);
 
         return response.stack.readBigNumber();
-    }
-
-    private async getNextSeqno(provider: ContractProvider): Promise<number> {
-        return (await this.getSeqno(provider)) + 1;
     }
 }
 


### PR DESCRIPTION
Align seqno (i.e. nonce) with EVM style. 

Replaces `msg::seqno == state::seqno + 1` check with  `msg::seqno == state::seqno`