### PR TITLE
feat(cli): add debug command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-.PHONY: help
-
 help: ## List of commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
@@ -14,3 +12,8 @@ deploy: ## Run deployment script
 
 tx: ## Execute a transaction to the Gateway
 	npx blueprint run transaction
+
+debug: ## Outputs Gateway's debug info
+	npx blueprint run debug
+
+.PHONY: help compile test deploy tx debug

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "start": "blueprint run",
         "build": "blueprint build",
         "prettier": "prettier -c .",
+        "prettier-fix": "prettier --write -c .",
         "test": "jest --verbose"
     },
     "main": "dist/index.js",

--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -1,0 +1,45 @@
+import { NetworkProvider } from "@ton/blueprint";
+import { Gateway } from "../wrappers/Gateway";
+import { formatCoin } from "../tests/utils";
+import { Address } from "@ton/core";
+
+const GATEWAY_ACCOUNT_ID_TESTNET = Address.parse(
+    '0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816'
+)
+
+export async function run(provider: NetworkProvider) {
+    const isTestnet = provider.network() === 'testnet';
+
+    const address = await provider.ui().inputAddress(
+        'Enter Gateway address',
+        isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined,
+    );
+
+    const gw = await provider.open(Gateway.createFromAddress(address));
+
+    const [state, balance, seqno] = await Promise.all([
+        gw.getGatewayState(),
+        gw.getBalance(),
+        gw.getSeqno()
+    ]);
+
+    console.log('Gateway', {
+        enabled: state.depositsEnabled,
+        tss: state.tss,
+        authority: state.authority.toRawString(),
+        value_locked: `${formatCoin(state.valueLocked)} TON`,
+        balance: `${formatCoin(balance)} TON`,
+        seqno: seqno,
+    });
+
+    console.log('Explorer link:')
+    console.log(addressLink(address, isTestnet));
+}
+
+function addressLink(address: Address, isTestnet: boolean): string {
+    const raw = address.toRawString();
+    return isTestnet
+        ? `https://testnet.tonscan.org/address/${raw}`
+        : `https://tonscan.org/address/${raw}`;
+
+}

--- a/scripts/debug.ts
+++ b/scripts/debug.ts
@@ -1,26 +1,25 @@
-import { NetworkProvider } from "@ton/blueprint";
-import { Gateway } from "../wrappers/Gateway";
-import { formatCoin } from "../tests/utils";
-import { Address } from "@ton/core";
+import { NetworkProvider } from '@ton/blueprint';
+import { Gateway } from '../wrappers/Gateway';
+import { formatCoin } from '../tests/utils';
+import { Address } from '@ton/core';
 
 const GATEWAY_ACCOUNT_ID_TESTNET = Address.parse(
-    '0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816'
-)
+    '0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816',
+);
 
 export async function run(provider: NetworkProvider) {
     const isTestnet = provider.network() === 'testnet';
 
-    const address = await provider.ui().inputAddress(
-        'Enter Gateway address',
-        isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined,
-    );
+    const address = await provider
+        .ui()
+        .inputAddress('Enter Gateway address', isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined);
 
     const gw = await provider.open(Gateway.createFromAddress(address));
 
     const [state, balance, seqno] = await Promise.all([
         gw.getGatewayState(),
         gw.getBalance(),
-        gw.getSeqno()
+        gw.getSeqno(),
     ]);
 
     console.log('Gateway', {
@@ -32,7 +31,7 @@ export async function run(provider: NetworkProvider) {
         seqno: seqno,
     });
 
-    console.log('Explorer link:')
+    console.log('Explorer link:');
     console.log(addressLink(address, isTestnet));
 }
 
@@ -41,5 +40,4 @@ function addressLink(address: Address, isTestnet: boolean): string {
     return isTestnet
         ? `https://testnet.tonscan.org/address/${raw}`
         : `https://tonscan.org/address/${raw}`;
-
 }


### PR DESCRIPTION
This PR adds a command that debugs the contract on-chain.

```sh
 ▸ ~/Code/zeta/protocol-contracts-ton ▸ git:feat/debug-cmd ✗ ▸ make debug                                  
npx blueprint run debug
Using file: debug
? Which network do you want to use? testnet
? Which wallet are you using? TON Connect compatible mobile wallet (example: Tonkeeper)
Connected to wallet at address: EQCVlMcZ7EyV9maDsvscoLCd5KQfb7CHukyNJluWpMzlDxYu
? Enter Gateway address (default: EQB6TUFJZyaq2yJ89NMTyVkS8f5sx0LBjr3jBv9ZiB2IFjrk) 
Gateway {
  enabled: true,
  tss: '0x8531a5ab847ff5b22d855633c25ed1da3255247e',
  authority: '0:a8098239a18ac69f0e6121da06c6c0735a04931c0e69e9f6b218e668fec775bd',
  value_locked: '1.992 TON',
  balance: '1.992408531 TON',
  seqno: 0
}
Explorer link:
https://testnet.tonscan.org/address/0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816
```