### PR TITLE
feat(cli): add command for debugging gateway transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ test: ## Run contract tests
 deploy: ## Run deployment script
 	npx blueprint run deploy
 
+debug-tx: ## Execute a transaction to the Gateway
+	@npx blueprint run debugTransaction
+
 tx: ## Execute a transaction to the Gateway
 	npx blueprint run transaction
 
@@ -33,4 +36,4 @@ lint: ## Lint the code
 fmt: ## Format the code
 	npm run prettier-fix
 
-.PHONY: help compile test deploy tx tx-localnet debug fmt
+.PHONY: help compile test deploy tx tx-localnet debug debug-tx fmt

--- a/scripts/common/index.ts
+++ b/scripts/common/index.ts
@@ -14,6 +14,28 @@ export async function inputGateway(provider: NetworkProvider): Promise<Address> 
         .inputAddress('Enter Gateway address', isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined);
 }
 
+export async function inputNumber(
+    provider: NetworkProvider,
+    prompt: string,
+    defaultValue: number,
+    min = 1,
+    max = 100,
+): Promise<number> {
+    const input = await provider.ui().input(`${prompt} (default is ${defaultValue})`);
+    if (input === '') {
+        return defaultValue;
+    }
+
+    const number = parseInt(input);
+
+    if (isNaN(number) || number < min || number > max) {
+        console.log(`Invalid number, using default value ${defaultValue}`);
+        return defaultValue;
+    }
+
+    return number;
+}
+
 export function parseTxHash(txHash: string): { lt: string; hash: string } {
     const chunks = txHash.split(':');
     if (chunks.length !== 2) {

--- a/scripts/common/index.ts
+++ b/scripts/common/index.ts
@@ -14,7 +14,7 @@ export async function inputGateway(provider: NetworkProvider): Promise<Address> 
         .inputAddress('Enter Gateway address', isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined);
 }
 
-export function parseTxHash(txHash: string): { lt: string, hash: string } {
+export function parseTxHash(txHash: string): { lt: string; hash: string } {
     const chunks = txHash.split(':');
     if (chunks.length !== 2) {
         throw new Error(`Invalid transaction hash "${txHash}"`);
@@ -36,7 +36,5 @@ export function addressLink(address: Address, isTestnet: boolean): string {
 }
 
 export function txLink(hash: string, isTestnet: boolean): string {
-    return isTestnet
-        ? `https://testnet.tonscan.org/tx/${hash}`
-        : `https://tonscan.org/tx/${hash}`;
+    return isTestnet ? `https://testnet.tonscan.org/tx/${hash}` : `https://tonscan.org/tx/${hash}`;
 }

--- a/scripts/common/index.ts
+++ b/scripts/common/index.ts
@@ -13,3 +13,30 @@ export async function inputGateway(provider: NetworkProvider): Promise<Address> 
         .ui()
         .inputAddress('Enter Gateway address', isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined);
 }
+
+export function parseTxHash(txHash: string): { lt: string, hash: string } {
+    const chunks = txHash.split(':');
+    if (chunks.length !== 2) {
+        throw new Error(`Invalid transaction hash "${txHash}"`);
+    }
+
+    const lt = chunks[0];
+
+    // input requires hex, but ton client accepts base64
+    const hash = Buffer.from(chunks[1], 'hex').toString('base64');
+
+    return { lt, hash };
+}
+
+export function addressLink(address: Address, isTestnet: boolean): string {
+    const raw = address.toRawString();
+    return isTestnet
+        ? `https://testnet.tonscan.org/address/${raw}`
+        : `https://tonscan.org/address/${raw}`;
+}
+
+export function txLink(hash: string, isTestnet: boolean): string {
+    return isTestnet
+        ? `https://testnet.tonscan.org/tx/${hash}`
+        : `https://tonscan.org/tx/${hash}`;
+}

--- a/scripts/debugTransaction.ts
+++ b/scripts/debugTransaction.ts
@@ -1,0 +1,157 @@
+import { NetworkProvider } from '@ton/blueprint';
+import { Gateway } from '../wrappers/Gateway';
+import * as common from './common';
+import { CommonMessageInfoInternal, fromNano, OpenedContract, Transaction } from '@ton/core';
+import { TonClient } from '@ton/ton';
+import { bufferToHexString, depositLogFromCell, GatewayOp, sliceToHexString } from '../types';
+
+let isTestnet = false;
+
+export async function run(provider: NetworkProvider) {
+    const client = resolveClient(provider);
+
+    isTestnet = provider.network() === 'testnet';
+
+    const gwAddress = await common.inputGateway(provider);
+
+    const gw = await provider.open(Gateway.createFromAddress(gwAddress));
+
+    const commands: Record<string,string> = {
+        'specific-tx': 'Explore specific transaction',
+        'last-txs': 'List last 10 transactions',
+    };
+
+    const cmd = await provider.ui().choose(
+        'Select command',
+        Object.keys(commands),
+        cmd => commands[cmd]
+    );
+
+
+    if (cmd === 'last-txs') {
+        await suppressException(async () => await fetchLastTransactions(client, gw));
+        return;
+    }
+
+    await suppressException(async () => {
+        const txHash = await provider.ui().input(`Enter transaction in a format <lt>:<hash>`);
+        await fetchTransaction(client, gw, txHash);
+    });
+}
+
+async function fetchLastTransactions(client: TonClient, gw: OpenedContract<Gateway>) {
+    // todo
+    console.log('Fetching last transactions...');
+}
+
+async function fetchTransaction(client: TonClient, gw: OpenedContract<Gateway>, txHash: string) {
+    const { lt, hash } = common.parseTxHash(txHash);
+
+    let tx: Transaction | null = null;
+
+    try {
+        tx = await client.getTransaction(gw.address, lt, hash);
+    } catch (error) {
+        console.error("getTransaction", error);
+        return
+    }
+
+    if (tx === null) {
+        console.error(`Transaction "${txHash}" not found`);
+        return;
+    }
+
+    const parsed = parseTransaction(tx, gw);
+
+    console.log('Transaction details', parsed);
+}
+
+function resolveClient(provider: NetworkProvider): TonClient {
+    const api = provider.api();
+
+    if (api instanceof TonClient) {
+        return api;
+    }
+
+    throw new Error('API is not a TonClient instance');
+}
+
+async function suppressException(fn: () => Promise<void>) {
+    try {
+        await fn();
+    } catch (error) {
+        console.error(error instanceof Error ? error.message : error);
+    }
+}
+
+function parseTransaction(tx: Transaction, gw: OpenedContract<Gateway>) {
+    return tx.inMessage?.info.type === 'internal'
+        ? parseInbound(tx, gw)
+        : parseOutbound(tx, gw);
+}
+
+function parseInbound(tx: Transaction, gw: OpenedContract<Gateway>) {
+    const info = tx.inMessage!.info as CommonMessageInfoInternal;
+    const hash = tx.hash().toString('hex');
+
+    let kv: Record<string, any> = {};
+
+    const slice = tx.inMessage!.body.beginParse()
+    const opCode = slice.loadUint(32);
+
+    switch (opCode) {
+        case GatewayOp.Donate:
+            kv.operation = 'donate';
+            kv.queryId = slice.loadUint(64);
+
+            break;
+        case GatewayOp.Deposit:
+            kv.operation = 'deposit';
+            kv.queryId = slice.loadUint(64);
+            kv.zevmRecipient = bufferToHexString(slice.loadBuffer(20));
+
+            const outDeposit = depositLogFromCell(tx.outMessages.get(0)!.body);
+            kv.depositAmount = formatCoin(outDeposit.amount);
+            kv.depositFee = formatCoin(outDeposit.depositFee);
+
+            break;
+        case GatewayOp.DepositAndCall:
+            kv.operation = 'deposit_and_call';
+            kv.queryId = slice.loadUint(64);
+            kv.zevmRecipient = bufferToHexString(slice.loadBuffer(20));
+            kv.callData = sliceToHexString(slice.loadRef().asSlice());
+
+            const outDepositAndCall = depositLogFromCell(tx.outMessages.get(0)!.body);
+            kv.depositAmount = formatCoin(outDepositAndCall.amount);
+            kv.depositFee = formatCoin(outDepositAndCall.depositFee);
+
+            break;
+        default:
+            kv.operation = `unknown (op: ${opCode})`;
+    }
+
+    return {
+        sender: info.src.toRawString(),
+        receiver: info.dest.toRawString(),
+        hash: `${tx.lt}:${hash}`,
+        timestamp: formatDate(tx.now),
+        txAmount: formatCoin(info.value.coins),
+        gas: formatCoin(tx.totalFees.coins),
+        link: common.txLink(hash, isTestnet),
+        payload: kv,
+    }
+}
+
+function parseOutbound(tx: Transaction, gw: OpenedContract<Gateway>) {
+    // todo
+    return {}
+}
+
+function formatDate(at: number) {
+    return new Date(at * 1000).toISOString();
+}
+
+function formatCoin(amount: bigint) {
+    return `${fromNano(amount)} TON`;
+}
+

--- a/scripts/debugTransaction.ts
+++ b/scripts/debugTransaction.ts
@@ -43,8 +43,12 @@ export async function run(provider: NetworkProvider) {
 }
 
 async function fetchLastTransactions(client: TonClient, gw: OpenedContract<Gateway>) {
-    // todo
-    console.log('Fetching last transactions...');
+    const txs = await client.getTransactions(gw.address, { limit: 10, archival: true });
+
+    for (const tx of txs) {
+        const parsed = parseTransaction(tx, gw);
+        console.log(parsed);
+    }
 }
 
 async function fetchTransaction(client: TonClient, gw: OpenedContract<Gateway>, txHash: string) {


### PR DESCRIPTION
This PR adds a new cli command:`make debug-tx`. It **decodes Gateway transactions** and supports both inbound and outbound txs simultaneously 

## List Recent Transactions
```sh
make debug-tx
Using file: debugTransaction
? Which network do you want to use? testnet
? Enter Gateway address (default: EQB6TUFJZyaq2yJ89NMTyVkS8f5sx0LBjr3jBv9ZiB2IFjrk)
? Select command List recent transactions
? Enter tx limit (default is 20) 3
{
  sender: '0:74a36900b786949a60c95ee20a56e583f908f2e957f3ffcb1e9770cc9edd408d',
  receiver: '0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816',
  hash: '34853344000003:5d0c1bcf20d86e1b34b9477a740c2c3e3c694fbb8a4b11a710e39cd990ad31c7',
  timestamp: '2025-05-21T10:53:00.000Z',
  txAmount: '0.125 TON',
  gas: '0.00415926 TON',
  link: 'https://testnet.tonscan.org/tx/5d0c1bcf20d86e1b34b9477a740c2c3e3c694fbb8a4b11a710e39cd990ad31c7',
  payload: {
    operation: 'deposit_and_call',
    queryId: 0,
    zevmRecipient: '0xa1eb8d65b765d259e7520b791bc4783adefdd998',
    callData: '0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000009746f74207a69656e730000000000000000000000000000000000000000000000',
    depositAmount: '0.1198 TON',
    depositFee: '0.0052 TON'
  }
}
{
  sender: '0:74a36900b786949a60c95ee20a56e583f908f2e957f3ffcb1e9770cc9edd408d',
  receiver: '0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816',
  hash: '34853281000003:58ddd475a83d96d6804cb011b5f28d943d8db51d0533db9792cff1c21ed54f5c',
  timestamp: '2025-05-21T10:50:21.000Z',
  txAmount: '0.2 TON',
  gas: '0.00051807 TON',
  link: 'https://testnet.tonscan.org/tx/58ddd475a83d96d6804cb011b5f28d943d8db51d0533db9792cff1c21ed54f5c',
  payload: { operation: 'donate', queryId: 0 }
}
{
  sender: '0:48097c7d2cab0ff3bb7bdda7689f25774431e48c73b3ec4761ad1248cc778c29',
  receiver: '0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816',
  hash: '34822967000003:cec62da579566632ea3e79c166a9b661722d2b0db7ce041b825a7d1745aeaf75',
  timestamp: '2025-05-20T14:07:34.000Z',
  txAmount: '0.01 TON',
  gas: '0.003790881 TON',
  link: 'https://testnet.tonscan.org/tx/cec62da579566632ea3e79c166a9b661722d2b0db7ce041b825a7d1745aeaf75',
  payload: {
    operation: 'deposit',
    queryId: 0,
    zevmRecipient: '0xb54f0d2ef810d60c47969587d7dcbd0dff5453ea',
    depositAmount: '0.006 TON',
    depositFee: '0.004 TON'
  }
}
```

## Explore a Specific Transaction
```sh
make debug-tx
Using file: debugTransaction
? Which network do you want to use? testnet
? Enter Gateway address (default: EQB6TUFJZyaq2yJ89NMTyVkS8f5sx0LBjr3jBv9ZiB2IFjrk)
? Select command Explore specific transaction
? Enter transaction in a format <lt>:<hash> 34616478000001:4b2da2a6cec51f2f6900394abea99cab2734b0a077166e4ff425604c2f28346d
Transaction details {
  sender: null,
  receiver: '0:7a4d41496726aadb227cf4d313c95912f1fe6cc742c18ebde306ff59881d8816',
  hash: '34616478000001:4b2da2a6cec51f2f6900394abea99cab2734b0a077166e4ff425604c2f28346d',
  timestamp: '2025-05-14T19:31:24.000Z',
  gas: '0.005374952 TON',
  link: 'https://testnet.tonscan.org/tx/4b2da2a6cec51f2f6900394abea99cab2734b0a077166e4ff425604c2f28346d',
  payload: {
    operation: 'withdraw',
    signature: '0x00af3055cabfa9a0db320712596c14a5a4ae0cebe3c232c912c9944e82a203e5ef31bf08beca81f205aead216dcd08ae6aff2b7429ed1a9f98e0a42d4259dc8d22',
    recipient: '0:48097c7d2cab0ff3bb7bdda7689f25774431e48c73b3ec4761ad1248cc778c29',
    amount: '0.01 TON',
    seqno: 57
  }
}
```