### PR TITLE
feat: gateway upgrade machinery

### DIFF
--- a/scripts/common/index.ts
+++ b/scripts/common/index.ts
@@ -1,5 +1,6 @@
 import { NetworkProvider } from '@ton/blueprint';
 import { Address } from '@ton/core';
+import chalk from 'chalk';
 
 // https://testnet.tonviewer.com/kQB6TUFJZyaq2yJ89NMTyVkS8f5sx0LBjr3jBv9ZiB2IFoFu
 export const GATEWAY_ACCOUNT_ID_TESTNET = Address.parse(
@@ -8,10 +9,9 @@ export const GATEWAY_ACCOUNT_ID_TESTNET = Address.parse(
 
 export async function inputGateway(provider: NetworkProvider): Promise<Address> {
     const isTestnet = provider.network() === 'testnet';
+    const fallback = isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined;
 
-    return await provider
-        .ui()
-        .inputAddress('Enter Gateway address', isTestnet ? GATEWAY_ACCOUNT_ID_TESTNET : undefined);
+    return await provider.ui().inputAddress('Enter Gateway address', fallback);
 }
 
 export async function inputNumber(
@@ -48,6 +48,23 @@ export async function inputString(
     return input;
 }
 
+export function clog(message: any, color: string = 'white') {
+    const chalkColor = (chalk as any)[color] || chalk.white;
+    console.log(chalkColor(message));
+}
+
+export function clogInfo(message: any) {
+    return clog(message, 'yellow');
+}
+
+export function clogSuccess(message: any) {
+    return clog(message, 'green');
+}
+
+export function clogError(message: any) {
+    return clog(message, 'red');
+}
+
 export function parseTxHash(txHash: string): { lt: string; hash: string } {
     const chunks = txHash.split(':');
     if (chunks.length !== 2) {
@@ -63,12 +80,13 @@ export function parseTxHash(txHash: string): { lt: string; hash: string } {
 }
 
 export function addressLink(address: Address, isTestnet: boolean): string {
-    const raw = address.toRawString();
-    return isTestnet
-        ? `https://testnet.tonscan.org/address/${raw}`
-        : `https://tonscan.org/address/${raw}`;
+    const base = isTestnet ? 'testnet.tonviewer.com' : 'tonviewer.com';
+
+    return `https://${base}/${address.toRawString()}`;
 }
 
 export function txLink(hash: string, isTestnet: boolean): string {
-    return isTestnet ? `https://testnet.tonscan.org/tx/${hash}` : `https://tonscan.org/tx/${hash}`;
+    const base = isTestnet ? 'testnet.tonviewer.com' : 'tonviewer.com';
+
+    return `https://${base}/transaction/${hash}`;
 }

--- a/scripts/upgrade.ts
+++ b/scripts/upgrade.ts
@@ -1,0 +1,264 @@
+import { NetworkProvider } from '@ton/blueprint';
+import { Address, beginCell, Cell, OpenedContract, toNano } from '@ton/core';
+import { Gateway } from '../wrappers/Gateway';
+import * as path from 'path';
+import * as fs from 'fs';
+import { cellFromBuffer, cellFromEncoded, formatCoin, GatewayState, GatewayOp } from '../types';
+import { Blockchain, SendMessageResult } from '@ton/sandbox';
+import {
+    inputGateway,
+    clog,
+    clogInfo,
+    inputString,
+    addressLink,
+    clogError,
+    clogSuccess,
+} from './common';
+import { flattenTransaction } from '@ton/test-utils';
+
+async function open(p: NetworkProvider, gwAddress: Address): Promise<OpenedContract<Gateway>> {
+    const gw = Gateway.createFromAddress(gwAddress);
+
+    const isDeployed = await p.isContractDeployed(gw.address);
+    if (!isDeployed) {
+        console.log(`Gateway is is not deployed to ${p.network()} network`);
+    }
+
+    return p.open(gw);
+}
+
+/**
+ * Execute a Gateway upgrade with a dry run.
+ * @param p NetworkProvider
+ */
+export async function run(p: NetworkProvider) {
+    const isTestnet = p.network() === 'testnet';
+    const sender = p.sender();
+    const gw = await open(p, await inputGateway(p));
+
+    // 1. Load new code (it should contain .hex key with the code)
+    clog('Provide a path to a compiled contract');
+
+    const compiledPath = path.resolve(
+        await inputString(p, 'Enter path', 'build/Gateway.compiled.json'),
+    );
+
+    clogInfo(`Reading compiled contract from ${compiledPath}`);
+
+    const jsonObj = JSON.parse(fs.readFileSync(compiledPath, 'utf8'));
+    const codeCell = cellFromEncoded(jsonObj.hex, 'hex');
+
+    clogInfo('Contract code loaded ✅');
+    clogInfo('Querying contract state ⏳');
+
+    // 2. Check state
+    const gwState = await gw.getGatewayState();
+    console.log('Gateway state', {
+        ...gwState,
+        valueLocked: formatCoin(gwState.valueLocked),
+        authority: gwState.authority.toRawString(),
+    });
+
+    // 3. Dry run the upgrade
+    await dryRunUpgrade(p, gw, codeCell);
+
+    // 4. Check authority
+    if (!gwState.authority.equals(sender.address!)) {
+        clogError('You are not the authority of the Gateway!');
+        clogError(`Your address: ${sender.address!.toRawString()}`);
+        clogError(`Gateway authority: ${gwState.authority.toRawString()}`);
+        process.exit(1);
+    }
+
+    // 5. Perform a real upgrade
+    const ok = await p.ui().prompt('Are you sure you want to upgrade the Gateway?');
+    if (!ok) {
+        console.log('Aborted');
+        process.exit(0);
+    }
+
+    await gw.sendUpdateCode(sender, codeCell);
+    clogInfo(`Sent tx to the Gateway. Check ${addressLink(gw.address, isTestnet)}`);
+}
+
+/**
+ * Performs a dry run of the upgrade
+ * @param networkProvider - NetworkProvider
+ * @param gwRemote - Deployed gateway on the network
+ * @param newCode - Cell
+ */
+async function dryRunUpgrade(
+    networkProvider: NetworkProvider,
+    gwRemote: OpenedContract<Gateway>,
+    newCode: Cell,
+) {
+    clogSuccess('Running a dry run of the upgrade 👾');
+    clog('Downloading gateway state & code from the network');
+
+    // 1. Download the contract with state
+    const contractState = await networkProvider.api().provider(gwRemote.address).getState();
+
+    if (contractState.state.type !== 'active') {
+        throw new Error('contract is not active');
+    } else if (!contractState.state.code) {
+        throw new Error('contract code is not available');
+    } else if (!contractState.state.data) {
+        throw new Error('contract data is not available');
+    }
+
+    const currentCode = cellFromBuffer(contractState.state.code);
+    const currentData = cellFromBuffer(contractState.state.data);
+
+    // 2. Create local blockchain sandbox with the contract state
+    clog('Creating a local blockchain sandbox');
+
+    const sandbox = await Blockchain.create();
+
+    // 2.1. Create a fake authority that will perform the upgrade
+    // By doing so, we can avoid having a real signature for dry-run.
+    // Also, we create a depositor that will perform a sample deposit.
+    const [authority, depositor] = await Promise.all([
+        sandbox.treasury('authority'),
+        sandbox.treasury('depositor'),
+    ]);
+
+    clog('Setting up the contract state in the sandbox');
+
+    await sandbox.setShardAccount(gwRemote.address, {
+        lastTransactionHash: bigIntFromBuffer(contractState.last!.hash),
+        lastTransactionLt: contractState.last!.lt,
+        account: {
+            addr: gwRemote.address,
+            storageStats: {
+                used: { cells: 1n, bits: BigInt(currentData.bits.length), publicCells: 0n },
+                lastPaid: 0,
+                duePayment: null,
+            },
+            storage: {
+                lastTransLt: contractState.last!.lt + 1n,
+                balance: { coins: contractState.balance },
+                state: {
+                    type: 'active',
+                    state: {
+                        code: currentCode,
+                        data: modifyState(currentData, authority.address),
+                    },
+                },
+            },
+        },
+    });
+
+    clog('Ensuring sandbox setup');
+
+    // 3. Run some sample get method on the contract to ensure it works locally
+    const gwSandbox = sandbox.openContract(Gateway.createFromAddress(gwRemote.address));
+
+    // check state matches
+    let [remoteState, sandboxState] = await Promise.all([
+        gwRemote.getGatewayState(),
+        gwSandbox.getGatewayState(),
+    ]);
+
+    if (!statePartiallyEquals(remoteState, sandboxState)) {
+        throw new Error(
+            `State mismatch: ${JSON.stringify(remoteState)} != ${JSON.stringify(sandboxState)}`,
+        );
+    }
+
+    // 4. Run the upgrade
+    clog('Running a dry run of the upgrade ⏳');
+
+    // 5. Verify the update code tx
+    const txUpdate = extractResultTx(
+        await gwSandbox.sendUpdateCode(authority.getSender(), newCode),
+    );
+
+    if (txUpdate.op !== GatewayOp.UpdateCode) {
+        throw new Error(`Expected update_code tx, got ${txUpdate.op}`);
+    } else if (!txUpdate.success) {
+        throw new Error('Update code tx failed');
+    }
+
+    clog('Contract updated, verifying dry-run result');
+
+    clog('Performing a sample deposit of 1 TON');
+
+    // 5.1 Perform a sample deposit of 1 TON
+    const zevmRecipient = '0x3863BeC603fD3a439fdF5996c714E8bB1AaEafaE';
+    const amount = toNano(1);
+    const txDeposit = extractResultTx(
+        await gwSandbox.sendDeposit(depositor.getSender(), amount, zevmRecipient),
+    );
+
+    if (txDeposit.op !== GatewayOp.Deposit) {
+        throw new Error(`Expected deposit tx, got ${txDeposit.op}`);
+    } else if (!txDeposit.success) {
+        throw new Error('Deposit tx failed');
+    }
+
+    // 5.2 Check getters
+    sandboxState = await gwSandbox.getGatewayState();
+    if (sandboxState.valueLocked <= remoteState.valueLocked) {
+        throw new Error('Value locked should be greater than before');
+    }
+
+    clogSuccess('Dry run completed ✅');
+}
+
+function bigIntFromBuffer(buff: Buffer): bigint {
+    return BigInt(`0x${buff.toString('hex')}`);
+}
+
+// doesn't check for authority address
+function statePartiallyEquals(a: GatewayState, b: GatewayState): boolean {
+    return (
+        a.depositsEnabled === b.depositsEnabled &&
+        a.valueLocked === b.valueLocked &&
+        a.tss === b.tss
+    );
+}
+
+/**
+ * Modifies the state of the contract to have a new authority
+ * @param original - original raw state
+ * @param newAuthority - new authority address (admin wallet)
+ * @returns Cell
+ */
+function modifyState(original: Cell, newAuthority: Address): Cell {
+    /*
+        ;; state.fc
+        () load_state() impure inline {
+            var cs = get_data().begin_parse();
+
+            state::deposits_enabled = cs~load_uint(size::deposits_enabled);
+            state::total_locked = cs~load_coins();
+            state::seqno = cs~load_uint(size::seqno);
+            state::tss_address = cs~load_bits(size::evm_address);
+            state::authority_address = cs~load_msg_addr();
+        }
+     */
+    const modified = beginCell();
+    const cs = original.beginParse();
+
+    // Copy everything, but change the authority
+    // 1 bit for deposits_enabled
+    // 32 bits for seqno
+    // 20 bytes for tss_address
+    modified.storeUint(cs.loadUint(1), 1);
+    modified.storeCoins(cs.loadCoins());
+    modified.storeUint(cs.loadUint(32), 32);
+    modified.storeBuffer(cs.loadBuffer(20));
+    modified.storeAddress(newAuthority);
+
+    return modified.asCell();
+}
+
+function extractResultTx(result: SendMessageResult) {
+    if (result.transactions.length !== 2) {
+        throw new Error('Expected 2 transactions, got ' + result.transactions.length);
+    }
+
+    const tx = result.transactions[1];
+
+    return flattenTransaction(tx);
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -2,6 +2,7 @@ import { beginCell, Cell, Message, Slice, Transaction } from '@ton/core';
 import { Wallet } from 'ethers';
 import { compileFunc } from '@ton-community/func-js';
 import { TransactionDescriptionGeneric } from '@ton/core/src/types/TransactionDescription';
+import { cellFromEncoded } from '../types';
 
 export interface TxFeeReport {
     txType: string;
@@ -97,8 +98,5 @@ export async function compileFuncInline(code: string): Promise<Cell> {
     // Bag of Cells
     const boc = result.codeBoc as string;
 
-    const cells = Cell.fromBoc(Buffer.from(boc, 'base64'));
-    expect(cells.length).toBe(1);
-
-    return cells[0];
+    return cellFromEncoded(boc);
 }

--- a/types/utils.ts
+++ b/types/utils.ts
@@ -136,3 +136,29 @@ function trimSuffix(str: string, suffix: string): string {
 
     return str;
 }
+
+/**
+ * Converts a BOC string to a Cell
+ * @param raw - BOC string (base64 or hex)
+ * @param encoding - Encoding of the BOC string
+ * @returns Cell
+ */
+export function cellFromEncoded(raw: string, encoding: 'base64' | 'hex' = 'base64'): Cell {
+    const buf = Buffer.from(raw, encoding);
+
+    try {
+        return cellFromBuffer(buf);
+    } catch (e) {
+        throw new Error(`Unable to parse BOC "${raw}" from ${encoding}: ${e}`);
+    }
+}
+
+export function cellFromBuffer(raw: Buffer): Cell {
+    const cells = Cell.fromBoc(raw);
+
+    if (cells.length !== 1) {
+        throw new Error(`Expected 1 cell, got ${cells.length}`);
+    }
+
+    return cells[0];
+}


### PR DESCRIPTION
This PR adds `npx run blueprint upgrade` command that upgrades the Gateway.

**Features**
- Upgrade from arbitrary compiled code
- Ensure & enforce authority
- Most importantly, perform a **dry-run**

**Dry runs** 

To gain confidence during the upgrade, a dry run is performed first. How it works:

- Fetch Gateway's current state & code from RPC
- Create a sandbox blockchain (TVM emulator) and provision the Gateway
- Perform upgrade locally
- Ensure the state is not broken
- Perform a sample deposits 